### PR TITLE
Added a bootloader tool to jump to the STM32 bootloader ROM CODE. Tes…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "files.associations": {
+    "pinconfigured.h": "c",
+    "variant.h": "c"
+  }
 }

--- a/lib/tools/bootloaderTools.cpp
+++ b/lib/tools/bootloaderTools.cpp
@@ -1,0 +1,43 @@
+
+#include "bootloaderTools.h"
+
+void JumpToBootloader(void) {
+  /*
+  In addition to the patterns described above, the user can execute bootloader
+  by performing a jump to system memory from user code. Before jumping to
+  bootloader: • Disable all peripheral clocks • Disable used PLL • Disable
+  interrupts • Clear pending interrupts
+  */
+
+  //! As we improve the code, we will add more steps to ensure a safe jump to
+  //! the bootloader.
+
+  /* Disable all interrupts */
+  __disable_irq();
+
+  /* Disable Systick timer */
+  SysTick->CTRL = 0;
+  SysTick->LOAD = 0;
+  SysTick->VAL = 0;
+
+  /* Set the clock to the default state */
+  HAL_RCC_DeInit();
+
+  /* Clear Interrupt Enable Register & Interrupt Pending Register */
+  for (uint8_t i = 0; i < (MCU_IRQS + 31u) / 32; i++) {
+    NVIC->ICER[i] = 0xFFFFFFFF;
+    NVIC->ICPR[i] = 0xFFFFFFFF;
+  }
+
+  // REMAP
+  SYSCFG->MEMRMP = 0x01;
+
+  /* Re-enable all interrupts */
+  __enable_irq();
+
+  // Set the MSP
+  __set_MSP((uint32_t)BOOTVTAB->Initial_SP);
+
+  // Jump to app firmware
+  BOOTVTAB->Reset_Handler();
+}

--- a/lib/tools/bootloaderTools.cpp
+++ b/lib/tools/bootloaderTools.cpp
@@ -1,6 +1,21 @@
 
 #include "bootloaderTools.h"
 
+volatile uint32_t BootAddr[] = {
+    [C0] = 0x1FFF0000,    [F030x8] = 0x1FFFEC00, [F030xC] = 0x1FFFD800,
+    [F03xx] = 0x1FFFEC00, [F05] = 0x1FFFEC00,    [F07] = 0x1FFFC800,
+    [F09] = 0x1FFFD800,   [F10xx] = 0x1FFFF000,  [F105] = 0x1FFFB000,
+    [F107] = 0x1FFFB000,  [F10XL] = 0x1FFFE000,  [F2] = 0x1FFF0000,
+    [F3] = 0x1FFFD800,    [F4] = 0x1FFF0000,     [F7] = 0x1FF00000,
+    [G0] = 0x1FFF0000,    [G4] = 0x1FFF0000,     [H503] = 0x0BF87000,
+    [H563] = 0x0BF97000,  [H573] = 0x0BF97000,   [H7x] = 0x1FF09800,
+    [H7A] = 0x1FF0A800,   [H7B] = 0x1FF0A000,    [L0] = 0x1FF00000,
+    [L1] = 0x1FF00000,    [L4] = 0x1FFF0000,     [L5] = 0x0BF90000,
+    [WBA] = 0x0BF88000,   [WBX] = 0x1FFF0000,    [WL] = 0x1FFF0000,
+    [U5] = 0x0BF90000,
+    // Initialize new models here
+};
+
 void JumpToBootloader(void) {
   /*
   In addition to the patterns described above, the user can execute bootloader

--- a/lib/tools/bootloaderTools.cpp
+++ b/lib/tools/bootloaderTools.cpp
@@ -23,6 +23,11 @@ void JumpToBootloader(void) {
   /* Set the clock to the default state */
   HAL_RCC_DeInit();
 
+  /* Disable peripehral */
+  HAL_DeInit();
+  // If needed to disable other peripherals, do it here, SPI, I2C, UART, and CAN
+  // should be disabled, but we can tested it first.
+
   /* Clear Interrupt Enable Register & Interrupt Pending Register */
   for (uint8_t i = 0; i < (MCU_IRQS + 31u) / 32; i++) {
     NVIC->ICER[i] = 0xFFFFFFFF;

--- a/lib/tools/bootloaderTools.h
+++ b/lib/tools/bootloaderTools.h
@@ -1,0 +1,45 @@
+#ifndef BOOTLOADER_TOOLS_H
+#define BOOTLOADER_TOOLS_H
+
+// Libraries
+#include "Arduino.h"
+
+#define BOOT_ADDR 0x1FFF0000  // my MCU boot code base address
+#define MCU_IRQS 70u          // no. of NVIC IRQ inputs
+#define BOOTVTAB ((BootVectorTable*)BOOT_ADDR)
+
+////////////////////////////////*
+////* Struct definitions *//////
+////////////////////////////////*
+
+typedef struct {
+  uint32_t* Initial_SP;
+  void (*Reset_Handler)(void);
+} BootVectorTable;
+
+////////////////////////////////*
+////* Function Prototypes *//////
+////////////////////////////////*
+
+/**
+ * @brief Initiates a jump to the system bootloader.
+ *
+ * This function prepares the system to enter the bootloader mode, typically for
+ * firmware updates. It performs necessary system cleanup and state preparation,
+ * ensuring a safe transition to the bootloader. The specific actions taken can
+ * include disabling interrupts, resetting peripheral states, and configuring
+ * system clocks. It may also involve setting specific flags or registers that
+ * the bootloader checks upon startup to determine whether to enter bootloader
+ * mode or continue with normal application execution.
+ *
+ * Note: The actual implementation details and the necessity of certain actions
+ * depend on the target microcontroller architecture and the bootloader's
+ * requirements. This function may require customization for different hardware
+ * setups.
+ *
+ * Usage:
+ *     JumpToBootloader();
+ */
+void JumpToBootloader(void);
+
+#endif  // BOOTLOADER_TOOLS_H

--- a/lib/tools/bootloaderTools.h
+++ b/lib/tools/bootloaderTools.h
@@ -4,8 +4,10 @@
 // Libraries
 #include "Arduino.h"
 
-#define BOOT_ADDR 0x1FFF0000  // my MCU boot code base address
-#define MCU_IRQS 70u          // no. of NVIC IRQ inputs
+#define BOOT_ADDR \
+  0x1FFF0000  // MCU bootloader address for STM32G431, need to change if needed
+              // for other MCUs.
+#define MCU_IRQS 71u  // Page number 28 in the reference manual for STM32G431
 #define BOOTVTAB ((BootVectorTable*)BOOT_ADDR)
 
 ////////////////////////////////*

--- a/lib/tools/bootloaderTools.h
+++ b/lib/tools/bootloaderTools.h
@@ -4,15 +4,55 @@
 // Libraries
 #include "Arduino.h"
 
-#define BOOT_ADDR \
-  0x1FFF0000  // MCU bootloader address for STM32G431, need to change if needed
-              // for other MCUs.
+#if defined(ARDUINO_GENERIC_G431C6UX) || defined(ARDUINO_GENERIC_G431C8UX) || \
+    defined(ARDUINO_GENERIC_G431CBUX) || defined(ARDUINO_GENERIC_G441CBUX)
+#define BOOTVTAB ((BootVectorTable*)BootAddr[G4])
 #define MCU_IRQS 71u  // Page number 28 in the reference manual for STM32G431
-#define BOOTVTAB ((BootVectorTable*)BOOT_ADDR)
+//! Add new MCU families here
+
+#else
+#error "Unsupported MCU family"
+#endif
+
+enum {
+  C0,
+  F030x8,
+  F030xC,
+  F03xx,
+  F05,
+  F07,
+  F09,
+  F10xx,
+  F105,
+  F107,
+  F10XL,
+  F2,
+  F3,
+  F4,
+  F7,
+  G0,
+  G4,
+  H503,
+  H563,
+  H573,
+  H7x,
+  H7A,
+  H7B,
+  L0,
+  L1,
+  L4,
+  L5,
+  WBA,
+  WBX,
+  WL,
+  U5
+};
 
 ////////////////////////////////*
-////* Struct definitions *//////
+////* Struct and variable definitions *//////
 ////////////////////////////////*
+
+extern volatile uint32_t BootAddr[];
 
 typedef struct {
   uint32_t* Initial_SP;

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ build_flags =
 build_src_filter =
   +<*>
   -<target/>
+  -<lib/>
   # version control
   -<.git/>
   -<.svn/>
@@ -33,12 +34,14 @@ board = genericSTM32G431CB
 build_flags = 
   ${env.build_flags}
   -Isrc/target/cln17_v1_5
+  -Isrc/lib/tools
   -D PIO_FRAMEWORK_ARDUINO_ENABLE_CDC ; Enable USB
   -D USBCON                           ; Enable SerialUSB
 
 build_src_filter = 
   ${env.build_src_filter}
   +<target/cln17_v1_5>
+  +<lib/tools>
 
 [env:cln17_v2_0_release]
 build_type = release
@@ -47,9 +50,12 @@ board = genericSTM32G431CB
 build_flags = 
   ${env.build_flags}
   -Isrc/target/cln17_v2_0
+  -Isrc/lib/tools
   -D PIO_FRAMEWORK_ARDUINO_ENABLE_CDC ; Enable USB
   -D USBCON                           ; Enable SerialUSB
 
 build_src_filter = 
   ${env.build_src_filter}
   +<target/cln17_v2_0>
+  +<lib/tools>
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 // This includes the target selected by the PIO build environment
 // The include error can be dismissed until we find a fix for the dev env.
+#include "bootloaderTools.h"
 #include "target.h"
 
 #ifdef TARGET_CLN17_V1_5
@@ -18,10 +19,27 @@
 #endif
 
 void setup() {
+  SerialUSB.begin(115200);
   pinMode(PINOUT::LED_GRN, OUTPUT);
+  pinMode(PINOUT::LED_RED, OUTPUT);
+  pinMode(PINOUT::LED_BLU, OUTPUT);
+
+  // Initialize LEDs
+  digitalWrite(PINOUT::LED_GRN, HIGH);
+  digitalWrite(PINOUT::LED_RED, HIGH);
+  digitalWrite(PINOUT::LED_BLU, HIGH);
 }
 
 void loop() {
+  // Jump to bootloader if 'b' is received
+  if (SerialUSB.available() > 0) {
+    char receivedChar = SerialUSB.read();
+    if (receivedChar == 'b') {
+      JumpToBootloader();
+    }
+  }
+
+  SerialUSB.println("Hello World!");
   digitalToggle(PINOUT::LED_GRN);
   delay(100);
 }


### PR DESCRIPTION
Tested with STM32CubeProgrammer DFU tool.

- Windows 11: the drivers are needed and can be found in "C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\Drivers\DFU_Driver".
- The STM32Cube install it automatically.