### PR TITLE
Block IO

### DIFF
--- a/lib/blocks/data_types.h
+++ b/lib/blocks/data_types.h
@@ -14,7 +14,7 @@
  * This type defines an array of four 16-bit integers representing the normalized phase
  * voltages.
  */
-using VoltgChannelslNormlzd = int16_t[4];
+using VoltgChannelslNormlzd = std::array<int16_t, 4>;
 
 /**
  * @struct VectorAxes2D_I32
@@ -23,8 +23,8 @@ using VoltgChannelslNormlzd = int16_t[4];
  * (X / sin / D axis) and cosine (Y / B / Q axis) projections.
  */
 struct VectorAxes2D_I32 {
-  int32_t sin; /* SIN or Projection on X / sin / D axis */
-  int32_t cos; /* COS or Projection on Y / B / Q axis */
+    int32_t sin; /* SIN or Projection on X / sin / D axis */
+    int32_t cos; /* COS or Projection on Y / B / Q axis */
 } __attribute__((packed));
 
 /**
@@ -34,8 +34,8 @@ struct VectorAxes2D_I32 {
  * radius.
  */
 struct VectorPolar2D_I32 {
-  int32_t ang; /* Angle in Int1.31 format */
-  int32_t rad; /* Radius */
+    int32_t ang; /* Angle in Int1.31 format */
+    int32_t rad; /* Radius */
 } __attribute__((packed));
 
 /**
@@ -45,8 +45,8 @@ struct VectorPolar2D_I32 {
  * (X / sin / D axis) and cosine (Y / B / Q axis) projections.
  */
 struct VectorAxes2D_I16 {
-  int16_t sin; /* Projection on X / sin / D axis */
-  int16_t cos; /* Projection on Y / B / Q axis */
+    int16_t sin; /* Projection on X / sin / D axis */
+    int16_t cos; /* Projection on Y / B / Q axis */
 } __attribute__((packed));
 
 /**
@@ -54,25 +54,25 @@ struct VectorAxes2D_I16 {
  * @brief Union to represent absolute position in terms of angle and rotations.
  */
 union AbsPosition {
-  /**
-   * @struct
-   * @brief Structure to split position into angle and rotations.
-   */
-  struct {
-    int32_t angle;      // Angle component of the position.
-    int32_t rotations;  // Rotations component of the position.
-  } split;
-  int64_t position;  // Combined 64-bit position value.
+    /**
+     * @struct
+     * @brief Structure to split position into angle and rotations.
+     */
+    struct {
+        int32_t angle;      // Angle component of the position.
+        int32_t rotations;  // Rotations component of the position.
+    } split;
+    int64_t position;  // Combined 64-bit position value.
 
-  /**
-   * @brief Constructor to initialize the union.
-   * @param r Rotations value.
-   * @param a Angle value.
-   */
-  AbsPosition(int32_t r, int32_t a) {
-    split.rotations = r;
-    split.angle = a;
-  }
+    /**
+     * @brief Constructor to initialize the union.
+     * @param r Rotations value.
+     * @param a Angle value.
+     */
+    AbsPosition(int32_t r, int32_t a) {
+        split.rotations = r;
+        split.angle = a;
+    }
 };
 
 #endif  // DATA_TYPES_H

--- a/lib/blocks/foc_setup.h
+++ b/lib/blocks/foc_setup.h
@@ -10,19 +10,16 @@ CurrentControlMode currentMode = VOLTAGE_EST;
 MotorType motor_type = STEPPER;
 
 PatternPWM pattern_pwm = ABCD;
-ModePWM pwm_mode = ALLIGNED_GND;
+Variable<ModePWM> pwm_mode = ALLIGNED_GND;
 
-VectorAxes2D_I32 voltage_target_mv = {.sin = 0, .cos = 0};  // temporary
-VectorPolar2D_I32 current_target_polar = {.ang = 0,
-                                          .rad = 0};          // current vector
-VectorAxes2D_I32 current_target_real = {.sin = 0, .cos = 0};  // temporary
+VectorAxes2D_I32 voltage_target_mv = {.sin = 0, .cos = 0};      // temporary
+VectorPolar2D_I32 current_target_polar = {.ang = 0, .rad = 0};  // current vector
+VectorAxes2D_I32 current_target_real = {.sin = 0, .cos = 0};    // temporary
 
 int32_t resistance = 3500;
 int16_t pwm_resolution = 2625;
 
-VoltageContainer voltg_container = {.voltg_norm = 580,
-                                    .voltg_mv = 12000,
-                                    .max_sup_voltage = 69000};
+VoltageContainer voltg_container = {.voltg_norm = 580, .voltg_mv = 12000, .max_sup_voltage = 69000};
 
 ControllerPIDFF_Setting pid_settgs = {0, 0, 0, 0};  // temp
 
@@ -34,17 +31,11 @@ CurrentVectorPWM currntVectorController(currentMode,
                                         voltg_container,
                                         pid_settgs);
 
-SelectorMotorType motor_sel(motor_type,
-                            currntVectorController.get_voltg_I16(),
-                            voltg_container.voltg_norm,
-                            INT16_MIN);
+SelectorMotorType motor_sel(motor_type, currntVectorController.get_voltg_I16(), voltg_container.voltg_norm, INT16_MIN);
 
 SelectorInterconnectPwm pwm_mux(pattern_pwm, motor_sel.getPwmChannels());
 
-ModuleDriverPWM pwm(pwm_mode,
-                    pwm_resolution,
-                    voltg_container.voltg_norm,
-                    pwm_mux.getPwmChannels());
+ModuleDriverPWM pwm(pwm_mode, pwm_resolution, voltg_container.voltg_norm, pwm_mux.getPwmChannels());
 
 uint32_t angleRaw = UINT32_MAX / 2;
 AbsPosition pos_offset(0, 0);
@@ -52,14 +43,14 @@ AbsPosition pos_offset(0, 0);
 BlockAbsolutePosition positionHandler(angleRaw, pos_offset, 20000);
 
 void tick() {
-  // positionHandler.tick();
+    // positionHandler.tick();
 
-  currntVectorController.tick();
+    currntVectorController.tick();
 
-  motor_sel.tick();
+    motor_sel.tick();
 
-  pwm_mux.tick();
-  pwm.tick();
+    pwm_mux.tick();
+    pwm.tick();
 }
 
 }  // namespace MOTOR_CONTROL

--- a/lib/blocks/generic_block.h
+++ b/lib/blocks/generic_block.h
@@ -9,13 +9,12 @@
 #ifndef GENERIC_BLOCK_H
 #define GENERIC_BLOCK_H
 
+#include <USBDevice.h>
 #include <float.h>
 #include <inttypes.h>
 #include "control_modes.h"
 
 #include "data_types.h"
-
-
 
 // ################### GENERIC BLOCK #################################
 
@@ -29,11 +28,11 @@
  */
 
 class Block {
- public:
-  /**
-   * @brief Pure virtual function of Block callback.
-   */
-  virtual void tick() = 0;
+   public:
+    /**
+     * @brief Pure virtual function of Block callback.
+     */
+    virtual void tick() = 0;
 };
 
 // ################### MACROS #################################
@@ -45,8 +44,8 @@ class Block {
  * @param name The name of the input variable.
  */
 #define BLOCK_INPUT(type, name) \
- protected:                     \
-  const type& name##_;
+   protected:                   \
+    const type& name##_;
 
 /**
  * @brief Macro to define an output channel in a Block.
@@ -54,13 +53,63 @@ class Block {
  * @param type The data type of the output.
  * @param name The name of the output variable.
  */
-#define BLOCK_OUTPUT(type, name)   \
- protected:                        \
-  type name##_;                    \
-                                   \
- public:                           \
-  const type& get_##name() const { \
-    return name##_;                \
-  }
+#define BLOCK_OUTPUT(type, name)     \
+   protected:                        \
+    type name##_;                    \
+                                     \
+   public:                           \
+    const type& get_##name() const { \
+        return name##_;              \
+    }
+
+// ################### BLOCK IO #################################
+
+template <typename T>
+class Input;
+
+template <typename T>
+class Output {
+    T value;
+
+   public:
+    constexpr Output<T>(T&& input) : value{input} {}
+
+    constexpr operator T&() { return this->value; }
+
+    constexpr T& operator=(T&& new_value) {
+        this->value = new_value;
+        return this->value;
+    };
+
+    // constexpr T& operator[](int i) { this->value[i] }
+
+    constexpr Input<T> asInput() { return this->value; }
+
+    friend Input<T>;
+};
+
+template <typename T>
+class Input {
+    const T& value;
+
+   public:
+    constexpr Input<T>(const T& as_input) : value{as_input} {}
+    constexpr Input<T>(const Output<T>& as_input) : value{as_input.value} {}
+    constexpr operator const T&() const { return this->value; }
+    constexpr const T& asValue() const { return this->value; }
+};
+
+template <typename T>
+using Variable = Output<T>;
+
+// void test() {
+//     Output<int> v(0);
+
+//     Input<int> i(v);
+
+//     v = 5;
+
+//     // i = 0;
+// }
 
 #endif  // GENERIC_BLOCK_H

--- a/lib/blocks/module_pwm_driver.h
+++ b/lib/blocks/module_pwm_driver.h
@@ -3,36 +3,35 @@
 
 #include "generic_block.h"
 
-
 class ModuleDriverPWM {
-  BLOCK_INPUT(ModePWM, mode);
-  const VoltgChannelslNormlzd& ch1234_;
-  BLOCK_INPUT(int16_t, sup_voltg);
-  BLOCK_INPUT(int16_t, pwm_res);
-  int16_t duty[4] = {0};
-  bool enb[4] = {0};
+    Input<ModePWM> mode_;
+    Input<int16_t> sup_voltg_;
+    Input<int16_t> pwm_res_;
 
- private:
-  /* data */
- public:
-  ModuleDriverPWM(const ModePWM& mode,
-                  const int16_t& pwm_resolution,
-                  const int16_t& sup_voltage,
-                  const VoltgChannelslNormlzd& ch1234)
-      : mode_(mode),
-        ch1234_(ch1234),
-        sup_voltg_(sup_voltage),
-        pwm_res_(pwm_resolution) {}
+    const VoltgChannelslNormlzd& ch1234_;
+    VoltgChannelslNormlzd duty = {0};
+    bool enb[4] = {0};
 
-  void tick() {
-    for (uint8_t i = 0; i < 4; i++) {
-      enb[i] = {bool(ch1234_[i] != INT16_MIN)};
-      if (ch1234_[i] <= 0) duty[i] = 0;
-      else duty[i] = (ch1234_[i] * pwm_res_) / sup_voltg_;
+   private:
+    /* data */
+   public:
+    ModuleDriverPWM(Input<ModePWM> mode,
+                    Input<int16_t> pwm_resolution,
+                    Input<int16_t> sup_voltage,
+                    Input<VoltgChannelslNormlzd> ch1234)
+        : mode_(mode), ch1234_(ch1234), sup_voltg_(sup_voltage), pwm_res_(pwm_resolution) {}
+
+    void tick() {
+        for (uint8_t i = 0; i < 4; i++) {
+            enb[i] = {bool(ch1234_[i] != INT16_MIN)};
+            if (ch1234_[i] <= 0)
+                duty[i] = 0;
+            else
+                duty[i] = (ch1234_[i] * pwm_res_) / sup_voltg_;
+        }
     }
-  }
 
-  constexpr const VoltgChannelslNormlzd& getPwmChannels() const { return duty; }
+    const Input<VoltgChannelslNormlzd> getPwmChannels() const { return duty; }
 };
 
 #endif  // MODULE_PWM_DRIVER_H

--- a/lib/blocks/voltg_pattern_control/selector_interconnect_pwm.h
+++ b/lib/blocks/voltg_pattern_control/selector_interconnect_pwm.h
@@ -75,7 +75,7 @@ class SelectorInterconnectPwm {
      * @param mode Reference to the current mode.
      * @param chABCD Reference to the input array containing PWM channels.
      */
-    constexpr SelectorInterconnectPwm(const Input<PatternPWM>& mode, const Input<VoltgChannelslNormlzd>& chABCD)
+    constexpr SelectorInterconnectPwm(const Input<PatternPWM> mode, const Input<VoltgChannelslNormlzd> chABCD)
         : mode_(mode), chABCD_(chABCD) {}
 
     /**
@@ -86,8 +86,8 @@ class SelectorInterconnectPwm {
         //     normalized_voltage[i] = chABCD_[(mode_ >> (i * 2)) & 0b11];
         // }
 
-        normalized_voltage = {chABCD_.asValue()[(mode_ >> (0 * 2)) & 0b11], chABCD_.asValue()[(mode_ >> (1 * 2)) & 0b11],
-                              chABCD_.asValue()[(mode_ >> (2 * 2)) & 0b11], chABCD_.asValue()[(mode_ >> (3 * 2)) & 0b11]};
+        normalized_voltage = {chABCD_[(mode_ >> (0 * 2)) & 0b11], chABCD_[(mode_ >> (1 * 2)) & 0b11],
+                              chABCD_[(mode_ >> (2 * 2)) & 0b11], chABCD_[(mode_ >> (3 * 2)) & 0b11]};
     }
 
     /**

--- a/lib/blocks/voltg_pattern_control/selector_interconnect_pwm.h
+++ b/lib/blocks/voltg_pattern_control/selector_interconnect_pwm.h
@@ -64,37 +64,37 @@
 #include "../data_types.h"
 
 class SelectorInterconnectPwm {
- private:
-  const VoltgChannelslNormlzd&
-      chABCD_;              ///< Reference to the array containing ABCD channels
-  const PatternPWM& mode_;  ///< Reference to the current mode
-  VoltgChannelslNormlzd output = {
-      INT16_MIN};  ///< Array to store the current output pattern
+   private:
+    Input<VoltgChannelslNormlzd> chABCD_;                           ///< Reference to the array containing ABCD channels
+    Input<PatternPWM> mode_;                                        ///< Reference to the current mode
+    Output<VoltgChannelslNormlzd> normalized_voltage{{INT16_MIN}};  ///< Array to store the current output pattern
 
- public:
-  /**
-   * @brief Constructor for SelectorInterconnectPwm.
-   * @param mode Reference to the current mode.
-   * @param chABCD Reference to the input array containing PWM channels.
-   */
-  constexpr SelectorInterconnectPwm(const PatternPWM& mode,
-                                    const VoltgChannelslNormlzd& chABCD)
-      : mode_(mode), chABCD_(chABCD) {}
+   public:
+    /**
+     * @brief Constructor for SelectorInterconnectPwm.
+     * @param mode Reference to the current mode.
+     * @param chABCD Reference to the input array containing PWM channels.
+     */
+    constexpr SelectorInterconnectPwm(const Input<PatternPWM>& mode, const Input<VoltgChannelslNormlzd>& chABCD)
+        : mode_(mode), chABCD_(chABCD) {}
 
-  /**
-   * @brief Updates the output pattern based on the current mode.
-   */
-  void tick() {
-    for (uint8_t i = 0; i < 4; i++) {
-      output[i] = chABCD_[(mode_ >> (i * 2)) & 0b11];
+    /**
+     * @brief Updates the output pattern based on the current mode.
+     */
+    void tick() {
+        // for (uint8_t i = 0; i < 4; i++) {
+        //     normalized_voltage[i] = chABCD_[(mode_ >> (i * 2)) & 0b11];
+        // }
+
+        normalized_voltage = {chABCD_.asValue()[(mode_ >> (0 * 2)) & 0b11], chABCD_.asValue()[(mode_ >> (1 * 2)) & 0b11],
+                              chABCD_.asValue()[(mode_ >> (2 * 2)) & 0b11], chABCD_.asValue()[(mode_ >> (3 * 2)) & 0b11]};
     }
-  }
 
-  /**
-   * @brief Returns the current PWM channels.
-   * @return Reference to the array of current PWM channels.
-   */
-  const VoltgChannelslNormlzd& getPwmChannels() const { return output; }
+    /**
+     * @brief Returns the current PWM channels.
+     * @return Reference to the array of current PWM channels.
+     */
+    const Input<VoltgChannelslNormlzd> getPwmChannels() const { return normalized_voltage; }
 };
 
 #endif  // SELECTOR_INTERCONNECT_PWM_H

--- a/src/interrupt_setup.h
+++ b/src/interrupt_setup.h
@@ -29,7 +29,7 @@ extern "C" void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
     if (htim->Instance == TIM2) {
         static bool underflow = true;
         if (underflow = !underflow) {
-            TIM2_Set_PWM_Values(MOTOR_CONTROL::pwm.getPwmChannels());
+            TIM2_Set_PWM_Values(MOTOR_CONTROL::pwm.getPwmChannels().asValue().data());
         } else {
             ADC1_StartDMAConversion();
         }
@@ -48,7 +48,6 @@ extern "C" void DMA1_Channel1_IRQHandler(void) {
         ADC_get_values(current_sensor_A, current_sensor_B, MOTOR_CONTROL::voltg_container.voltg_norm, voltage_vref, temperature);
         MOTOR_CONTROL::current_target_polar.ang += 1 << 23;
         // MOTOR_CONTROL::angleRaw += 1 << 24;
-        
 
         MOTOR_CONTROL::voltg_container.voltg_mv = (MOTOR_CONTROL::voltg_container.voltg_norm * 69000) >> 15;  // Danger
         MOTOR_CONTROL::tick();


### PR DESCRIPTION
Move definition of Blocks Input and Output to a template base system, 


An `Output` is a full fledge L-value (it actually exist on the stack and it is assignable)
An `Input` is a const-reference to a L-value (read-only)

For compatibility with existing code `Input<T>`  contains a reference to a value of type `T`, in a ideal implementation it should reference a `Output<T>`

Also starting the process of moving `T[N]` to `std::array<T,N>` for being fully explicit on size and preparing for generic-type-math / helpers implementation

Many other changes are automatic by the linter